### PR TITLE
Fix RTL layout to stack footer below content

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -92,7 +92,8 @@
     text-align: right;
   }
 
-  [dir="rtl"] .flex {
+  /* Reverse only row-based flex layouts in RTL to avoid breaking vertical stacks */
+  [dir="rtl"] .flex:not(.flex-col):not(.flex-col-reverse) {
     flex-direction: row-reverse;
   }
 
@@ -168,7 +169,8 @@
   text-align: right;
 }
 
-[dir="rtl"] .flex {
+/* Reverse only row-based flex layouts in RTL to avoid breaking vertical stacks */
+[dir="rtl"] .flex:not(.flex-col):not(.flex-col-reverse) {
   flex-direction: row-reverse;
 }
 


### PR DESCRIPTION
## Summary
- prevent RTL styles from forcing every flex container into `row-reverse`

## Testing
- `npm test` *(fails: ReferenceError: exports is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a18838420832b920373f6aa64d328